### PR TITLE
cowboy_protocol: start_link using proc_lib version, not BIF, for better ...

### DIFF
--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -62,7 +62,7 @@
 
 -spec start_link(ranch:ref(), inet:socket(), module(), opts()) -> {ok, pid()}.
 start_link(Ref, Socket, Transport, Opts) ->
-	Pid = spawn_link(?MODULE, init, [Ref, Socket, Transport, Opts]),
+	Pid = proc_lib:spawn_link(?MODULE, init, [Ref, Socket, Transport, Opts]),
 	{ok, Pid}.
 
 %% Internal.


### PR DESCRIPTION
...error reports
